### PR TITLE
Organize TODOs and clean comments

### DIFF
--- a/TODO_SUMMARY.md
+++ b/TODO_SUMMARY.md
@@ -1,0 +1,32 @@
+# TODO Summary
+
+This document categorizes all `TODO` comments found in the repository on 2025-06-18.
+
+## Counts
+
+- Total TODOs: 91
+- Tasks: 85
+- Open issues: 6
+
+## Open Issues
+
+The following TODO comments likely represent bugs or outstanding issues:
+
+- `e2e/setup/cleanupUser.ts:35` – fix deletion of all user sessions by email
+- `client/src/hooks/Files/useFileHandling.ts:59` – dynamic localization should be removed
+- `client/src/hooks/Files/useFileHandling.ts:69` – dynamic localization should be removed
+- `api/server/services/Runs/methods.js:10` – maxRetries not yet implemented
+- `api/server/routes/__tests__/config.spec.js:38` – HTTP request tests fail with 404 in CI
+- `api/app/clients/tools/util/fileSearch.js:115` – results should be sorted by relevance
+
+## Tasks
+
+Remaining TODOs cover various improvements and feature work. Examples include:
+
+- Adding agent models (packages/data-provider/src/config.ts)
+- Handling streaming of non-text (client/src/hooks/SSE/useContentHandler.ts)
+- Cost handling and mask support in image tools
+- Configurable parameters in SidePanel components
+- Cleaning up endpoint types and schemas
+
+Use this file as a starting point for creating tracking issues.

--- a/client/src/components/ui/InputNumber.tsx
+++ b/client/src/components/ui/InputNumber.tsx
@@ -6,10 +6,6 @@ import RCInputNumber from 'rc-input-number';
 import * as InputNumberPrimitive from 'rc-input-number';
 import { cn } from '~/utils';
 
-// TODO help needed
-// React.ElementRef<typeof LabelPrimitive.Root>,
-// React.ComponentPropsWithoutRef<typeof LabelPrimitive.Root>
-
 const InputNumber = React.forwardRef<
   React.ElementRef<typeof RCInputNumber>,
   InputNumberPrimitive.InputNumberProps

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -202,7 +202,6 @@ export default [
     files: ['api/**/*.js', 'config/**/*.js'],
     rules: {
       // API
-      // TODO: maybe later to error.
       'no-unused-const': 'off',
       'no-unused-vars': 'off',
       'no-async-promise-executor': 'off',
@@ -212,7 +211,6 @@ export default [
     files: ['client/src/**/*.tsx', 'client/src/**/*.ts', 'client/src/**/*.jsx', 'client/src/**/*.js'],
     rules: {
       // Client a11y
-      // TODO: maybe later to error.
       'jsx-a11y/no-noninteractive-element-interactions': 'off',
       'jsx-a11y/label-has-associated-control': 'off',
       'jsx-a11y/no-static-element-interactions': 'off',


### PR DESCRIPTION
## Summary
- remove outdated TODO comments in `eslint.config.mjs` and `InputNumber.tsx`
- add `TODO_SUMMARY.md` documenting remaining TODOs

## Testing
- `npm run lint` *(fails: Cannot find package '@typescript-eslint/eslint-plugin')*
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685301e8d688832087aa019e5b6520bc