### PR TITLE
Add Node version requirement

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,6 +82,9 @@
     "url": "https://github.com/danny-avila/LibreChat/issues"
   },
   "homepage": "https://librechat.ai/",
+  "engines": {
+    "node": ">=20"
+  },
   "devDependencies": {
     "@axe-core/playwright": "^4.10.1",
     "@eslint/compat": "^1.2.6",


### PR DESCRIPTION
## Summary
- specify minimum supported Node version in `package.json`

## Testing
- `npm ci`
- `npx prettier --write package.json`
- `npm run lint` *(fails: disallow literal string error)*
- `npm run test:api` *(fails: `jest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685301c8d3008320a4d26a4b13a8c789