### PR TITLE
Fix env update script regex

### DIFF
--- a/utils/test_update_env.py
+++ b/utils/test_update_env.py
@@ -1,0 +1,30 @@
+import os
+import sys
+import tempfile
+import unittest
+
+sys.path.append(os.path.dirname(__file__))
+from update_env import update_env_file_with_local_env
+
+class UpdateEnvTestCase(unittest.TestCase):
+    def test_digits_in_variable_name(self):
+        """Variables containing digits should be processed correctly."""
+        input_content = "VAR1=GET_FROM_LOCAL_ENV\nFOO=bar\n"
+        with tempfile.NamedTemporaryFile('w', delete=False) as infile:
+            infile.write(input_content)
+            input_path = infile.name
+        with tempfile.NamedTemporaryFile('w', delete=False) as outfile:
+            output_path = outfile.name
+        try:
+            os.environ['VAR1'] = 'value1'
+            update_env_file_with_local_env(input_path, output_path)
+            with open(output_path) as f:
+                lines = f.readlines()
+            self.assertIn('VAR1=value1\n', lines)
+            self.assertIn('FOO=bar\n', lines)
+        finally:
+            os.unlink(input_path)
+            os.unlink(output_path)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/utils/update_env.py
+++ b/utils/update_env.py
@@ -47,7 +47,8 @@ def update_env_file_with_local_env(input_file_path, output_file_path):
     lines = read_env_file(input_file_path)
     updated_lines = []
     # Regex pattern to match lines ending with "GET_FROM_LOCAL_ENV"
-    env_var_pattern = re.compile(r'^\s*([A-Z_]+)=GET_FROM_LOCAL_ENV\s*$')
+    # Allow digits within environment variable names
+    env_var_pattern = re.compile(r'^\s*([A-Z0-9_]+)=GET_FROM_LOCAL_ENV\s*$')
     missing_vars = []
     updated_vars = []
 


### PR DESCRIPTION
## Summary
- allow digits in `utils/update_env.py` regex
- add regression test to cover variables with digits

## Testing
- `python -m unittest utils/test_update_env.py`


------
https://chatgpt.com/codex/tasks/task_e_685301b997488320953aaceb81ba7709