### PR TITLE
Replace console.log with logger

### DIFF
--- a/api/server/middleware/requireLdapAuth.js
+++ b/api/server/middleware/requireLdapAuth.js
@@ -1,18 +1,14 @@
 const passport = require('passport');
+const { logger } = require('~/config');
 
 const requireLdapAuth = (req, res, next) => {
   passport.authenticate('ldapauth', (err, user, info) => {
     if (err) {
-      console.log({
-        title: '(requireLdapAuth) Error at passport.authenticate',
-        parameters: [{ name: 'error', value: err }],
-      });
+      logger.error('(requireLdapAuth) Error at passport.authenticate', { error: err });
       return next(err);
     }
     if (!user) {
-      console.log({
-        title: '(requireLdapAuth) Error: No user',
-      });
+      logger.warn('(requireLdapAuth) Error: No user');
       return res.status(404).send(info);
     }
     req.user = user;

--- a/api/server/services/Runs/handle.js
+++ b/api/server/services/Runs/handle.js
@@ -204,8 +204,8 @@ async function _handleRun({ openai, run_id, thread_id }) {
     //   // Define logic for handling steps with 'queued' status
     // },
     final: async ({ step, runStatus, stepsByStatus }) => {
-      console.log(`Final step for ${run_id} with status ${runStatus}`);
-      console.dir(step, { depth: null });
+      logger.debug(`Final step for ${run_id} with status ${runStatus}`);
+      logger.debug(step);
 
       const promises = [];
       promises.push(openai.beta.threads.messages.list(thread_id, defaultOrderQuery));

--- a/client/src/components/Artifacts/useDebounceCodeBlock.ts
+++ b/client/src/components/Artifacts/useDebounceCodeBlock.ts
@@ -4,13 +4,14 @@ import debounce from 'lodash/debounce';
 import { useSetRecoilState } from 'recoil';
 import { codeBlocksState, codeBlockIdsState } from '~/store/artifacts';
 import type { CodeBlock } from '~/common';
+import { logger } from '~/utils';
 
 export function useDebounceCodeBlock() {
   const setCodeBlocks = useSetRecoilState(codeBlocksState);
   const setCodeBlockIds = useSetRecoilState(codeBlockIdsState);
 
   const updateCodeBlock = useCallback((codeBlock: CodeBlock) => {
-    console.log('Updating code block:', codeBlock);
+    logger.log('artifacts', 'Updating code block:', codeBlock);
     setCodeBlocks((prev) => ({
       ...prev,
       [codeBlock.id]: codeBlock,

--- a/client/src/components/Auth/Login.tsx
+++ b/client/src/components/Auth/Login.tsx
@@ -3,7 +3,7 @@ import { useEffect, useState } from 'react';
 import { useAuthContext } from '~/hooks/AuthContext';
 import type { TLoginLayoutContext } from '~/common';
 import { ErrorMessage } from '~/components/Auth/ErrorMessage';
-import { getLoginError } from '~/utils';
+import { getLoginError, logger } from '~/utils';
 import { useLocalize } from '~/hooks';
 import LoginForm from './LoginForm';
 import SocialButton from '~/components/Auth/SocialButton';
@@ -40,7 +40,7 @@ function Login() {
 
   useEffect(() => {
     if (shouldAutoRedirect) {
-      console.log('Auto-redirecting to OpenID provider...');
+      logger.log('auth', 'Auto-redirecting to OpenID provider...');
       window.location.href = `${startupConfig.serverDomain}/oauth/openid`;
     }
   }, [shouldAutoRedirect, startupConfig]);

--- a/client/src/components/Bookmarks/BookmarkEditDialog.tsx
+++ b/client/src/components/Bookmarks/BookmarkEditDialog.tsx
@@ -62,7 +62,7 @@ const BookmarkEditDialog = ({
 
           setTimeout(() => {
             const tagElement = document.getElementById(vars.tag ?? '');
-            console.log('tagElement', tagElement);
+            logger.log('bookmarks', 'tagElement', tagElement);
             if (!tagElement) {
               return;
             }

--- a/client/src/components/Chat/Input/AudioRecorder.tsx
+++ b/client/src/components/Chat/Input/AudioRecorder.tsx
@@ -4,7 +4,7 @@ import { ListeningIcon, Spinner } from '~/components/svg';
 import { useLocalize, useSpeechToText } from '~/hooks';
 import { TooltipAnchor } from '~/components/ui';
 import { globalAudioId } from '~/common';
-import { cn } from '~/utils';
+import { cn, logger } from '~/utils';
 
 export default function AudioRecorder({
   disabled,
@@ -35,7 +35,7 @@ export default function AudioRecorder({
       if (text) {
         const globalAudio = document.getElementById(globalAudioId) as HTMLAudioElement | null;
         if (globalAudio) {
-          console.log('Unmuting global audio');
+          logger.log('audio', 'Unmuting global audio');
           globalAudio.muted = false;
         }
         ask({ text });

--- a/client/src/components/Chat/Input/Files/FileRow.tsx
+++ b/client/src/components/Chat/Input/Files/FileRow.tsx
@@ -44,10 +44,10 @@ export default function FileRow({
         tool_resource,
       ),
     onSuccess: () => {
-      console.log('Files deleted');
+      logger.log('files', 'Files deleted');
     },
     onError: (error) => {
-      console.log('Error deleting files:', error);
+      logger.error('files', 'Error deleting files:', error);
     },
   });
 

--- a/client/src/components/Chat/Menus/BookmarkMenu.tsx
+++ b/client/src/components/Chat/Menus/BookmarkMenu.tsx
@@ -38,7 +38,7 @@ const BookmarkMenu: FC = () => {
     onSuccess: (newTags: string[], vars) => {
       updateConvoTags(newTags);
       const tagElement = document.getElementById(vars.tag);
-      console.log('tagElement', tagElement);
+      logger.log('bookmark', 'tagElement', tagElement);
       if (tagElement) {
         setTimeout(() => tagElement.focus(), 2);
       }
@@ -51,7 +51,7 @@ const BookmarkMenu: FC = () => {
     },
     onMutate: (vars) => {
       const tagElement = document.getElementById(vars.tag);
-      console.log('tagElement', tagElement);
+      logger.log('bookmark', 'tagElement', tagElement);
       if (tagElement) {
         setTimeout(() => tagElement.focus(), 2);
       }

--- a/client/src/components/Chat/Menus/Presets/EditPresetDialog.tsx
+++ b/client/src/components/Chat/Menus/Presets/EditPresetDialog.tsx
@@ -9,6 +9,7 @@ import {
   removeFocusOutlines,
   mapEndpoints,
   getConvoSwitchLogic,
+  logger,
 } from '~/utils';
 import { Input, Label, SelectDropDown, Dialog, DialogClose, DialogButton } from '~/components';
 import { useSetIndexOptions, useLocalize, useDebouncedInput } from '~/hooks';
@@ -78,7 +79,7 @@ const EditPresetDialog = ({
     }
 
     if (!models.includes(preset.model ?? '')) {
-      console.log('setting model', models[0]);
+      logger.log('presets', 'setting model', models[0]);
       setOption('model')(models[0]);
     }
 
@@ -91,7 +92,7 @@ const EditPresetDialog = ({
       preset.agentOptions.model &&
       !models.includes(preset.agentOptions.model)
     ) {
-      console.log('setting agent model', models[0]);
+      logger.log('presets', 'setting agent model', models[0]);
       setAgentOption('model')(models[0]);
     }
   }, [preset, queryClient, setOption, setAgentOption]);

--- a/client/src/components/Chat/Messages/Content/MessageContent.tsx
+++ b/client/src/components/Chat/Messages/Content/MessageContent.tsx
@@ -6,6 +6,7 @@ import Error from '~/components/Messages/Content/Error';
 import Thinking from '~/components/Artifacts/Thinking';
 import { DelayedRender } from '~/components/ui';
 import { useChatContext } from '~/Providers';
+import { logger } from '~/utils';
 import MarkdownLite from './MarkdownLite';
 import EditMessage from './EditMessage';
 import { useLocalize } from '~/hooks';
@@ -23,7 +24,7 @@ export const ErrorMessage = ({
 }) => {
   const localize = useLocalize();
   if (text === 'Error connecting to server, try refreshing the page.') {
-    console.log('error message', message);
+    logger.error('chat', 'error message', message);
     return (
       <Suspense
         fallback={

--- a/client/src/components/Chat/Presentation.tsx
+++ b/client/src/components/Chat/Presentation.tsx
@@ -8,6 +8,7 @@ import Artifacts from '~/components/Artifacts/Artifacts';
 import { SidePanelGroup } from '~/components/SidePanel';
 import { useSetFilesToDelete } from '~/hooks';
 import { EditorProvider } from '~/Providers';
+import { logger } from '~/utils';
 import store from '~/store';
 
 export default function Presentation({ children }: { children: React.ReactNode }) {
@@ -18,11 +19,11 @@ export default function Presentation({ children }: { children: React.ReactNode }
 
   const { mutateAsync } = useDeleteFilesMutation({
     onSuccess: () => {
-      console.log('Temporary Files deleted');
+      logger.log('files', 'Temporary Files deleted');
       setFilesToDelete({});
     },
     onError: (error) => {
-      console.log('Error deleting temporary files:', error);
+      logger.error('files', 'Error deleting temporary files:', error);
     },
   });
 

--- a/client/src/components/Conversations/Fork.tsx
+++ b/client/src/components/Conversations/Fork.tsx
@@ -8,7 +8,7 @@ import { GitCommit, GitBranchPlus, ListTree } from 'lucide-react';
 import { TranslationKeys, useLocalize, useNavigateToConvo } from '~/hooks';
 import { useForkConvoMutation } from '~/data-provider';
 import { useToastContext } from '~/Providers';
-import { cn } from '~/utils';
+import { cn, logger } from '~/utils';
 import store from '~/store';
 
 interface PopoverButtonProps {
@@ -355,7 +355,7 @@ export default function Fork({
                     checked={remember}
                     onChange={(event) => {
                       const checked = event.target.checked;
-                      console.log('checked', checked);
+                      logger.log('fork', 'checked', checked);
                       if (checked) {
                         showToast({
                           message: localize('com_ui_fork_remember_checked'),

--- a/client/src/components/Files/FileList/DataTableFile.tsx
+++ b/client/src/components/Files/FileList/DataTableFile.tsx
@@ -36,6 +36,7 @@ import { TrashIcon, Spinner } from '~/components/svg';
 import useLocalize from '~/hooks/useLocalize';
 import ActionButton from '../ActionButton';
 import UploadFileButton from './UploadFileButton';
+import { logger } from '~/utils';
 
 interface DataTableProps<TData, TValue> {
   columns: ColumnDef<TData, TValue>[];
@@ -93,7 +94,7 @@ export default function DataTableFile<TData, TValue>({
           <div className="mt-3 flex w-full flex-row justify-center gap-x-3 md:m-0 md:justify-start">
             <ActionButton
               onClick={() => {
-                console.log('click');
+                logger.log('files', 'action click');
               }}
             />
             <Button
@@ -152,7 +153,7 @@ export default function DataTableFile<TData, TValue>({
               onChange={(event) => table.getColumn('filename')?.setFilterValue(event.target.value)}
               className="max-w-sm border-border-medium placeholder:text-text-secondary"
             />
-            <UploadFileButton onClick={() => console.log('click')} />
+            <UploadFileButton onClick={() => logger.log('files', 'upload click')} />
           </div>
         </div>
       </div>

--- a/client/src/components/Files/FileList/FilePreview.tsx
+++ b/client/src/components/Files/FileList/FilePreview.tsx
@@ -7,6 +7,7 @@ import DeleteIconButton from '../DeleteIconButton';
 import VectorStoreButton from '../VectorStore/VectorStoreButton';
 import { CircleIcon, Clock3Icon, InfoIcon } from 'lucide-react';
 import { useParams } from 'react-router-dom';
+import { logger } from '~/utils';
 
 const tempFile: TFile = {
   filename: 'File1.jpg',
@@ -57,14 +58,14 @@ export default function FilePreview() {
           <div>
             <DeleteIconButton
               onClick={() => {
-                console.log('click');
+                logger.log('files', 'delete click');
               }}
             />
           </div>
           <div className="w-40">
             <VectorStoreButton
               onClick={() => {
-                console.log('click');
+                logger.log('files', 'vector store click');
               }}
             />
           </div>
@@ -136,7 +137,7 @@ export default function FilePreview() {
                   <Button
                     className="m-0 ml-3 h-full bg-transparent p-0 text-[#666666] hover:bg-slate-200"
                     onClick={() => {
-                      console.log('Remove from vector store');
+                      logger.log('files', 'Remove from vector store');
                     }}
                     variant={'ghost'}
                   >
@@ -164,7 +165,7 @@ export default function FilePreview() {
                   <Button
                     className="m-0 ml-3 h-full bg-transparent p-0 text-[#666666] hover:bg-slate-200"
                     onClick={() => {
-                      console.log('Remove from thread');
+                      logger.log('files', 'Remove from thread');
                     }}
                   >
                     <TrashIcon className="m-0 p-0" />

--- a/client/src/components/Files/FileList/FileSidePanel.tsx
+++ b/client/src/components/Files/FileList/FileSidePanel.tsx
@@ -6,6 +6,7 @@ import { Button, Input } from '~/components/ui';
 import { ListFilter } from 'lucide-react';
 import UploadFileButton from './UploadFileButton';
 import { useLocalize } from '~/hooks';
+import { logger } from '~/utils';
 
 const fakeFiles = [
   {
@@ -145,7 +146,7 @@ export default function FileSidePanel() {
   const localize = useLocalize();
   const deleteFile = (id: string | undefined) => {
     // Define delete functionality here
-    console.log(`Deleting File with id: ${id}`);
+    logger.log('files', `Deleting File with id: ${id}`);
   };
 
   return (
@@ -162,7 +163,7 @@ export default function FileSidePanel() {
             placeholder={localize('com_files_filter')}
             value={''}
             onChange={() => {
-              console.log('changed');
+              logger.log('files', 'changed');
             }}
             className="max-w-sm border-border-light placeholder:text-text-secondary"
           />
@@ -170,7 +171,7 @@ export default function FileSidePanel() {
         <div className="w-1/3">
           <UploadFileButton
             onClick={() => {
-              console.log('Upload');
+              logger.log('files', 'Upload');
             }}
           />
         </div>

--- a/client/src/components/Files/FileList/UploadFileModal.tsx
+++ b/client/src/components/Files/FileList/UploadFileModal.tsx
@@ -2,7 +2,7 @@ import React, { useState, ChangeEvent } from 'react';
 import AttachFile from '~/components/Chat/Input/Files/AttachFile';
 import { Button, Dialog, DialogContent, DialogHeader, DialogTitle, Input } from '~/components/ui';
 import { useLocalize } from '~/hooks';
-import { cn } from '~/utils';
+import { cn, logger } from '~/utils';
 
 const UploadFileModal = ({ open, onOpenChange }) => {
   const localize = useLocalize();
@@ -72,7 +72,7 @@ const UploadFileModal = ({ open, onOpenChange }) => {
               <Button
                 className="w-full rounded-md border border-black bg-black p-0 text-white"
                 onClick={() => {
-                  console.log('upload file');
+                  logger.log('files', 'upload file');
                 }}
               >
                 Upload

--- a/client/src/components/Files/VectorStore/VectorStorePreview.tsx
+++ b/client/src/components/Files/VectorStore/VectorStorePreview.tsx
@@ -7,6 +7,7 @@ import UploadFileButton from '../FileList/UploadFileButton';
 import UploadFileModal from '../FileList/UploadFileModal';
 import { BarChart4Icon, Clock3, FileClock, FileIcon, InfoIcon, PlusIcon } from 'lucide-react';
 import { useParams } from 'react-router-dom';
+import { logger } from '~/utils';
 
 const tempVectorStore = {
   _id: 'vs_NeHK4JidLKJ2qo23dKLLK',
@@ -111,7 +112,7 @@ export default function VectorStorePreview() {
           <div>
             <DeleteIconButton
               onClick={() => {
-                console.log('click');
+                logger.log('files', 'delete vector store');
               }}
             />
           </div>
@@ -202,7 +203,7 @@ export default function VectorStorePreview() {
                   <div className="content-center text-nowrap">{file.createdAt?.toString()}</div>
                   <Button
                     className="my-0 ml-3 h-min bg-transparent p-0 text-[#666666] hover:bg-slate-200"
-                    onClick={() => console.log('click')}
+                    onClick={() => logger.log('files', 'remove file')}
                   >
                     <TrashIcon className="m-0 p-0" />
                   </Button>

--- a/client/src/components/Files/VectorStore/VectorStoreSidePanel.tsx
+++ b/client/src/components/Files/VectorStore/VectorStoreSidePanel.tsx
@@ -8,6 +8,7 @@ import ActionButton from '../ActionButton';
 import DeleteIconButton from '../DeleteIconButton';
 import { ListFilter } from 'lucide-react';
 import { useLocalize } from '~/hooks';
+import { logger } from '~/utils';
 
 const fakeVectorStores: TVectorStore[] = [
   {
@@ -212,7 +213,7 @@ export default function VectorStoreSidePanel() {
   const localize = useLocalize();
   const deleteVectorStore = (id: string | undefined) => {
     // Define delete functionality here
-    console.log(`Deleting VectorStore with id: ${id}`);
+    logger.log('files', `Deleting VectorStore with id: ${id}`);
   };
 
   return (
@@ -230,7 +231,7 @@ export default function VectorStoreSidePanel() {
               placeholder={localize('com_files_filter')}
               value={''}
               onChange={() => {
-                console.log('changed');
+                logger.log('files', 'changed');
               }}
               className="max-w-sm border-border-light placeholder:text-text-secondary"
             />
@@ -238,7 +239,7 @@ export default function VectorStoreSidePanel() {
           <div className="w-1/3">
             <VectorStoreButton
               onClick={() => {
-                console.log('Add Vector Store');
+                logger.log('files', 'Add Vector Store');
               }}
             />
           </div>

--- a/client/src/components/Nav/SettingsTabs/Data/ImportConversations.tsx
+++ b/client/src/components/Nav/SettingsTabs/Data/ImportConversations.tsx
@@ -5,7 +5,7 @@ import { useUploadConversationsMutation } from '~/data-provider';
 import { useToastContext } from '~/Providers';
 import { Spinner } from '~/components/svg';
 import { useLocalize } from '~/hooks';
-import { cn } from '~/utils';
+import { cn, logger } from '~/utils';
 
 function ImportConversations() {
   const localize = useLocalize();
@@ -52,7 +52,7 @@ function ImportConversations() {
     try {
       await startUpload(_file);
     } catch (error) {
-      console.log('file handling error', error);
+      logger.error('files', 'file handling error', error);
       setError('An error occurred while processing the file.');
     }
   };

--- a/client/src/components/Prompts/Groups/DashGroupItem.tsx
+++ b/client/src/components/Prompts/Groups/DashGroupItem.tsx
@@ -8,7 +8,7 @@ import CategoryIcon from '~/components/Prompts/Groups/CategoryIcon';
 import OGDialogTemplate from '~/components/ui/OGDialogTemplate';
 import { useLocalize, useAuthContext } from '~/hooks';
 import { TrashIcon } from '~/components/svg';
-import { cn } from '~/utils/';
+import { cn, logger } from '~/utils/';
 
 interface DashGroupItemProps {
   group: TPromptGroup;
@@ -49,7 +49,7 @@ function DashGroupItemComponent({ group, instanceProjectId }: DashGroupItemProps
   const { isLoading } = updateGroup;
 
   const handleSaveRename = useCallback(() => {
-    console.log(group._id ?? '', { name: nameInputValue });
+    logger.log('prompts', group._id ?? '', { name: nameInputValue });
     updateGroup.mutate({ id: group._id ?? '', payload: { name: nameInputValue } });
   }, [group._id, nameInputValue, updateGroup]);
 

--- a/client/src/components/Share/MessageIcon.tsx
+++ b/client/src/components/Share/MessageIcon.tsx
@@ -3,7 +3,7 @@ import type { TMessage, Assistant, Agent } from 'librechat-data-provider';
 import type { TMessageProps } from '~/common';
 import MessageEndpointIcon from '../Endpoints/MessageEndpointIcon';
 import ConvoIconURL from '~/components/Endpoints/ConvoIconURL';
-import { getIconEndpoint } from '~/utils';
+import { getIconEndpoint, logger } from '~/utils';
 import { UserIcon } from '../svg';
 
 export default function MessageIcon(
@@ -41,7 +41,7 @@ export default function MessageIcon(
     }
     return result;
   }, [assistant, agent, assistantAvatar, agentAvatar]);
-  console.log('MessageIcon', {
+  logger.log('share', 'MessageIcon', {
     endpoint,
     iconURL,
     assistantName,

--- a/client/src/components/SidePanel/Builder/ActionsInput.tsx
+++ b/client/src/components/SidePanel/Builder/ActionsInput.tsx
@@ -21,6 +21,7 @@ import { ActionsTable, columns } from './ActionsTable';
 import { useUpdateAction } from '~/data-provider';
 import useLocalize from '~/hooks/useLocalize';
 import { Spinner } from '~/components/svg';
+import { logger } from '~/utils';
 
 const debouncedValidation = debounce(
   (input: string, callback: (result: ValidationResult) => void) => {
@@ -109,7 +110,7 @@ export default function ActionsInput({
   });
 
   const saveAction = handleSubmit((authFormData) => {
-    console.log('authFormData', authFormData);
+    logger.log('actions', 'authFormData', authFormData);
     const currentAssistantId = assistant_id ?? '';
     if (!currentAssistantId) {
       // alert user?
@@ -227,7 +228,7 @@ export default function ActionsInput({
             </button> */}
             <select
               id="example-schema"
-              onChange={(e) => console.log(e.target.value)}
+              onChange={(e) => logger.log('actions', e.target.value)}
               className="border-token-border-medium h-8 min-w-[100px] rounded-lg border bg-transparent px-2 py-0 text-sm"
             >
               <option value="label">{localize('com_ui_examples')}</option>

--- a/client/src/components/SidePanel/Builder/AssistantAvatar.tsx
+++ b/client/src/components/SidePanel/Builder/AssistantAvatar.tsx
@@ -20,7 +20,7 @@ import { useToastContext, useAssistantsMapContext } from '~/Providers';
 import { AssistantAvatar, NoImage, AvatarMenu } from './Images';
 // import { Spinner } from '~/components/svg';
 import { useLocalize } from '~/hooks';
-import { formatBytes } from '~/utils';
+import { formatBytes, logger } from '~/utils';
 
 function Avatar({
   endpoint,
@@ -142,7 +142,7 @@ function Avatar({
     }
 
     if (sharedUploadCondition && createMutation.data.id) {
-      console.log('[AssistantAvatar] Uploading Avatar after Assistant Creation');
+      logger.log('assistants', '[AssistantAvatar] Uploading Avatar after Assistant Creation');
 
       const formData = new FormData();
       formData.append('file', input, input.name);
@@ -182,7 +182,7 @@ function Avatar({
 
       if (!assistant_id) {
         // wait for successful form submission before uploading avatar
-        console.log('[AssistantAvatar] No assistant_id, will wait until form submission + upload');
+        logger.log('assistants', '[AssistantAvatar] No assistant_id, will wait until form submission + upload');
         return;
       }
 

--- a/client/src/components/SidePanel/Builder/ContextButton.tsx
+++ b/client/src/components/SidePanel/Builder/ContextButton.tsx
@@ -5,7 +5,7 @@ import { useChatContext, useToastContext } from '~/Providers';
 import { useDeleteAssistantMutation } from '~/data-provider';
 import DialogTemplate from '~/components/ui/DialogTemplate';
 import { useLocalize, useSetIndexOptions } from '~/hooks';
-import { cn, removeFocusOutlines } from '~/utils/';
+import { cn, removeFocusOutlines, logger } from '~/utils/';
 import { TrashIcon } from '~/components/svg';
 
 export default function ContextButton({
@@ -39,7 +39,7 @@ export default function ContextButton({
       });
 
       if (createMutation.data?.id !== undefined) {
-        console.log('[deleteAssistant] resetting createMutation');
+        logger.log('assistants', '[deleteAssistant] resetting createMutation');
         createMutation.reset();
       }
 

--- a/client/src/hooks/Audio/useAudioRef.ts
+++ b/client/src/hooks/Audio/useAudioRef.ts
@@ -1,4 +1,5 @@
 import { useEffect, useRef } from 'react';
+import { logger } from '~/utils';
 
 export default function useCustomAudioRef({
   setIsPlaying,
@@ -9,7 +10,7 @@ export default function useCustomAudioRef({
   useEffect(() => {
     const handleEnded = () => {
       setIsPlaying(false);
-      console.log('message audio ended');
+      logger.log('audio', 'message audio ended');
       if (audioRef.current) {
         URL.revokeObjectURL(audioRef.current.src);
       }
@@ -17,12 +18,12 @@ export default function useCustomAudioRef({
 
     const handleStart = () => {
       setIsPlaying(true);
-      console.log('message audio started');
+      logger.log('audio', 'message audio started');
     };
 
     const handlePause = () => {
       setIsPlaying(false);
-      console.log('message audio paused');
+      logger.log('audio', 'message audio paused');
     };
 
     const audioElement = audioRef.current;

--- a/client/src/hooks/Audio/useCustomAudioRef.ts
+++ b/client/src/hooks/Audio/useCustomAudioRef.ts
@@ -1,4 +1,5 @@
 import { useEffect, useRef } from 'react';
+import { logger } from '~/utils';
 
 interface CustomAudioElement extends HTMLAudioElement {
   customStarted?: boolean;
@@ -25,7 +26,7 @@ export default function useCustomAudioRef({
 
     const handleEnded = () => {
       setIsPlaying(false);
-      console.log('global audio ended');
+      logger.log('audio', 'global audio ended');
       if (audioRef.current) {
         audioRef.current.customEnded = true;
         URL.revokeObjectURL(audioRef.current.src);
@@ -34,14 +35,14 @@ export default function useCustomAudioRef({
 
     const handleStart = () => {
       setIsPlaying(true);
-      console.log('global audio started');
+      logger.log('audio', 'global audio started');
       if (audioRef.current) {
         audioRef.current.customStarted = true;
       }
     };
 
     const handlePause = () => {
-      console.log('global audio paused');
+      logger.log('audio', 'global audio paused');
       if (audioRef.current) {
         audioRef.current.customPaused = true;
       }
@@ -61,7 +62,7 @@ export default function useCustomAudioRef({
         lastTimeUpdate = currentTime;
 
         if (sameTimeUpdateCount >= 1) {
-          console.log('Detected end of audio based on time update');
+          logger.log('audio', 'Detected end of audio based on time update');
           audioRef.current.pause();
           handleEnded();
         }

--- a/client/src/hooks/Audio/usePauseGlobalAudio.ts
+++ b/client/src/hooks/Audio/usePauseGlobalAudio.ts
@@ -2,6 +2,7 @@ import { useCallback } from 'react';
 import { useRecoilState, useSetRecoilState } from 'recoil';
 import { globalAudioId } from '~/common';
 import store from '~/store';
+import { logger } from '~/utils';
 
 function usePauseGlobalAudio(index = 0) {
   /* Global Audio Variables */
@@ -15,7 +16,7 @@ function usePauseGlobalAudio(index = 0) {
     if (globalAudioURL != null && globalAudioURL !== '') {
       const globalAudio = document.getElementById(globalAudioId);
       if (globalAudio) {
-        console.log('Pausing global audio', globalAudioURL);
+        logger.log('audio', 'Pausing global audio', globalAudioURL);
         (globalAudio as HTMLAudioElement).pause();
         setGlobalIsPlaying(false);
       }

--- a/client/src/hooks/AuthContext.tsx
+++ b/client/src/hooks/AuthContext.tsx
@@ -21,6 +21,7 @@ import {
 } from '~/data-provider';
 import { TAuthConfig, TUserContext, TAuthContext, TResError } from '~/common';
 import useTimeout from './useTimeout';
+import { logger } from '~/utils';
 import store from '~/store';
 
 const AuthContext = createContext<TAuthContext | undefined>(undefined);
@@ -128,7 +129,7 @@ const AuthContextProvider = ({
 
   const silentRefresh = useCallback(() => {
     if (authConfig?.test === true) {
-      console.log('Test mode. Skipping silent refresh.');
+      logger.log('auth', 'Test mode. Skipping silent refresh.');
       return;
     }
     refreshToken.mutate(undefined, {
@@ -137,7 +138,7 @@ const AuthContextProvider = ({
         if (token) {
           setUserContext({ token, isAuthenticated: true, user });
         } else {
-          console.log('Token is not present. User is not authenticated.');
+          logger.warn('auth', 'Token is not present. User is not authenticated.');
           if (authConfig?.test === true) {
             return;
           }
@@ -145,7 +146,7 @@ const AuthContextProvider = ({
         }
       },
       onError: (error) => {
-        console.log('refreshToken mutation error:', error);
+        logger.error('auth', 'refreshToken mutation error:', error);
         if (authConfig?.test === true) {
           return;
         }
@@ -182,7 +183,7 @@ const AuthContextProvider = ({
 
   useEffect(() => {
     const handleTokenUpdate = (event) => {
-      console.log('tokenUpdated event received event');
+      logger.log('auth', 'tokenUpdated event received event');
       const newToken = event.detail;
       setUserContext({
         token: newToken,

--- a/client/src/hooks/Files/useDeleteFilesFromTable.tsx
+++ b/client/src/hooks/Files/useDeleteFilesFromTable.tsx
@@ -2,6 +2,7 @@ import { useQueryClient } from '@tanstack/react-query';
 import { QueryKeys } from 'librechat-data-provider';
 import type { BatchFile, TFile } from 'librechat-data-provider';
 import { useDeleteFilesMutation } from '~/data-provider';
+import { logger } from '~/utils';
 import useFileDeletion from './useFileDeletion';
 
 export default function useDeleteFilesFromTable(callback?: () => void) {
@@ -21,7 +22,7 @@ export default function useDeleteFilesFromTable(callback?: () => void) {
       return { filesToDeleteMap };
     },
     onSuccess: (data, variables, context) => {
-      console.log('Files deleted');
+      logger.log('files', 'Files deleted');
       const { filesToDeleteMap } = context as { filesToDeleteMap: Map<string, BatchFile> };
 
       queryClient.setQueryData([QueryKeys.files], (oldFiles: TFile[] | undefined) => {
@@ -33,7 +34,7 @@ export default function useDeleteFilesFromTable(callback?: () => void) {
       callback?.();
     },
     onError: (error) => {
-      console.log('Error deleting files:', error);
+      logger.error('Error deleting files:', error);
       callback?.();
     },
   });

--- a/client/src/hooks/Files/useDragHelpers.ts
+++ b/client/src/hooks/Files/useDragHelpers.ts
@@ -14,6 +14,7 @@ import {
 import type * as t from 'librechat-data-provider';
 import type { DropTargetMonitor } from 'react-dnd';
 import useFileHandling from './useFileHandling';
+import { logger } from '~/utils';
 import store, { ephemeralAgentByConvoId } from '~/store';
 
 export default function useDragHelpers() {
@@ -48,7 +49,7 @@ export default function useDragHelpers() {
     () => ({
       accept: [NativeTypes.FILE],
       drop(item: { files: File[] }) {
-        console.log('drop', item.files);
+        logger.log('files', 'drop', item.files);
         if (!isAgents) {
           handleFiles(item.files);
           return;

--- a/client/src/hooks/Files/useFileDeletion.ts
+++ b/client/src/hooks/Files/useFileDeletion.ts
@@ -5,6 +5,7 @@ import type * as t from 'librechat-data-provider';
 import type { UseMutateAsyncFunction } from '@tanstack/react-query';
 import type { ExtendedFile, GenericSetter } from '~/common';
 import useSetFilesToDelete from './useSetFilesToDelete';
+import { logger } from '~/utils';
 
 type FileMapSetter = GenericSetter<Map<string, ExtendedFile>>;
 
@@ -40,7 +41,7 @@ const useFileDeletion = ({
         assistant_id,
         tool_resource,
       });
-      console.log('Deleting files:', filesToDelete, payload);
+      logger.log('files', 'Deleting files:', filesToDelete, payload);
       mutateAsync({ files: filesToDelete, ...payload });
       setFileDeleteBatch([]);
     },

--- a/client/src/hooks/Files/useFileHandling.ts
+++ b/client/src/hooks/Files/useFileHandling.ts
@@ -92,7 +92,7 @@ const useFileHandling = (params?: UseFileHandling) => {
     {
       onSuccess: (data) => {
         clearUploadTimer(data.temp_file_id);
-        console.log('upload success', data);
+        logger.log('files', 'upload success', data);
         if (agent_id) {
           queryClient.refetchQueries([QueryKeys.agent, agent_id]);
           return;
@@ -127,7 +127,7 @@ const useFileHandling = (params?: UseFileHandling) => {
       },
       onError: (_error, body) => {
         const error = _error as TError | undefined;
-        console.log('upload error', error);
+        logger.error('upload error', error);
         const file_id = body.get('file_id');
         clearUploadTimer(file_id as string);
         deleteFileById(file_id as string);
@@ -295,7 +295,7 @@ const useFileHandling = (params?: UseFileHandling) => {
         await startUpload(extendedFile);
       } catch (error) {
         deleteFileById(file_id);
-        console.log('file handling error', error);
+        logger.error('file handling error', error);
         setError('com_error_files_process');
       }
     }

--- a/client/src/hooks/Input/useQueryParams.ts
+++ b/client/src/hooks/Input/useQueryParams.ts
@@ -225,7 +225,7 @@ export default function useQueryParams({
         const newUrl = window.location.pathname;
         window.history.replaceState({}, '', newUrl);
         processedRef.current = true;
-        console.log('Parameters processed successfully');
+        logger.log('params', 'Parameters processed successfully');
         clearInterval(intervalId);
       };
 

--- a/client/src/hooks/Input/useTextToSpeechExternal.ts
+++ b/client/src/hooks/Input/useTextToSpeechExternal.ts
@@ -3,6 +3,7 @@ import { useState, useMemo, useRef, useCallback, useEffect } from 'react';
 import { useTextToSpeechMutation, useVoicesQuery } from '~/data-provider';
 import { useToastContext } from '~/Providers/ToastContext';
 import useLocalize from '~/hooks/useLocalize';
+import { logger } from '~/utils';
 import store from '~/store';
 
 const createFormData = (text: string, voice: string) => {
@@ -62,7 +63,7 @@ function useTextToSpeechExternal({
         error.message &&
         error.message.includes('The play() request was interrupted by a call to pause()')
       ) {
-        console.log('Play request was interrupted by a call to pause()');
+        logger.warn('Play request was interrupted by a call to pause()');
         initializeAudio();
         return playPromise().catch(console.error);
       }
@@ -74,7 +75,7 @@ function useTextToSpeechExternal({
     });
 
     newAudio.onended = () => {
-      console.log('Cached message audio ended');
+      logger.log('audio', 'Cached message audio ended');
       URL.revokeObjectURL(blobUrl);
       setIsSpeaking(false);
     };

--- a/client/src/hooks/Input/useTextarea.ts
+++ b/client/src/hooks/Input/useTextarea.ts
@@ -18,6 +18,7 @@ import { useInteractionHealthCheck } from '~/data-provider';
 import { useChatContext } from '~/Providers/ChatContext';
 import useLocalize from '~/hooks/useLocalize';
 import { globalAudioId } from '~/common';
+import { logger } from '~/utils';
 import store from '~/store';
 
 type KeyEvent = KeyboardEvent<HTMLTextAreaElement>;
@@ -182,7 +183,7 @@ export default function useTextarea({
       if ((isNonShiftEnter || isCtrlEnter) && !isComposingInput) {
         const globalAudio = document.getElementById(globalAudioId) as HTMLAudioElement | undefined;
         if (globalAudio) {
-          console.log('Unmuting global audio');
+          logger.log('audio', 'Unmuting global audio');
           globalAudio.muted = false;
         }
         submitButtonRef.current?.click();

--- a/client/src/hooks/SSE/useSSE.ts
+++ b/client/src/hooks/SSE/useSSE.ts
@@ -18,6 +18,7 @@ import type { TResData } from '~/common';
 import { useGenTitleMutation, useGetStartupConfig, useGetUserBalance } from '~/data-provider';
 import { useAuthContext } from '~/hooks/AuthContext';
 import useEventHandlers from './useEventHandlers';
+import { logger } from '~/utils';
 import store from '~/store';
 
 const clearDraft = (conversationId?: string | null) => {
@@ -128,7 +129,7 @@ export default function useSSE(
         const { plugins } = data;
         finalHandler(data, { ...submission, plugins } as EventSubmission);
         (startupConfig?.balance?.enabled ?? false) && balanceQuery.refetch();
-        console.log('final', data);
+        logger.log('sse', 'final', data);
         return;
       } else if (data.created != null) {
         const runId = v4();
@@ -172,7 +173,7 @@ export default function useSSE(
 
     sse.addEventListener('open', () => {
       setAbortScroll(false);
-      console.log('connection is opened');
+      logger.log('sse', 'connection is opened');
     });
 
     sse.addEventListener('cancel', async () => {
@@ -219,11 +220,11 @@ export default function useSSE(
           return;
         } catch (error) {
           /* token refresh failed, continue handling the original 401 */
-          console.log(error);
+          logger.error('sse', error);
         }
       }
 
-      console.log('error in server stream.');
+      logger.error('sse', 'error in server stream.');
       (startupConfig?.balance?.enabled ?? false) && balanceQuery.refetch();
 
       let data: TResData | undefined = undefined;
@@ -231,7 +232,7 @@ export default function useSSE(
         data = JSON.parse(e.data) as TResData;
       } catch (error) {
         console.error(error);
-        console.log(e);
+        logger.error('sse', e);
         setIsSubmitting(false);
       }
 

--- a/client/src/hooks/ThemeContext.tsx
+++ b/client/src/hooks/ThemeContext.tsx
@@ -2,7 +2,7 @@
 // source: https://plainenglish.io/blog/light-and-dark-mode-in-react-web-application-with-tailwind-css-89674496b942
 import { useSetRecoilState } from 'recoil';
 import React, { createContext, useState, useEffect } from 'react';
-import { getInitialTheme, applyFontSize } from '~/utils';
+import { getInitialTheme, applyFontSize, logger } from '~/utils';
 import store from '~/store';
 
 type ProviderValue = {
@@ -64,7 +64,7 @@ export const ThemeProvider = ({ initialTheme, children }) => {
     try {
       applyFontSize(JSON.parse(fontSize));
     } catch (error) {
-      console.log(error);
+      logger.error('theme', error);
     }
     // Reason: This effect should only run once, and `setFontSize` is a stable function
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/client/src/hooks/useNewConvo.ts
+++ b/client/src/hooks/useNewConvo.ts
@@ -54,10 +54,10 @@ const useNewConvo = (index = 0) => {
 
   const { mutateAsync } = useDeleteFilesMutation({
     onSuccess: () => {
-      console.log('Files deleted');
+      logger.log('files', 'Files deleted');
     },
     onError: (error) => {
-      console.log('Error deleting files:', error);
+      logger.error('files', 'Error deleting files:', error);
     },
   });
 

--- a/client/src/hooks/useTimeout.tsx
+++ b/client/src/hooks/useTimeout.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef } from 'react';
+import { logger } from '~/utils';
 
 type TUseTimeoutParams = {
   callback: (error: string | number | boolean | null) => void;
@@ -17,7 +18,7 @@ function useTimeout({ callback, delay = 400 }: TUseTimeoutParams) {
 
     // Set new timeout
     if (value != null && value) {
-      console.log(value);
+      logger.log('timeout', value);
       timeout.current = setTimeout(() => {
         callback(value);
       }, delay);

--- a/client/src/utils/files.ts
+++ b/client/src/utils/files.ts
@@ -8,6 +8,7 @@ import {
 import type { TFile, EndpointFileConfig } from 'librechat-data-provider';
 import type { QueryClient } from '@tanstack/react-query';
 import type { ExtendedFile } from '~/common';
+import { logger } from '~/utils';
 import SheetPaths from '~/components/svg/Files/SheetPaths';
 import TextPaths from '~/components/svg/Files/TextPaths';
 import FilePaths from '~/components/svg/Files/FilePaths';
@@ -251,7 +252,7 @@ export const validateFiles = ({
     }
 
     if (!checkType(originalFile.type, supportedMimeTypes)) {
-      console.log(originalFile);
+      logger.log('files', originalFile);
       setError('Currently, unsupported file type: ' + originalFile.type);
       return false;
     }

--- a/client/src/utils/resetConvo.ts
+++ b/client/src/utils/resetConvo.ts
@@ -1,4 +1,5 @@
 import type { TMessage } from 'librechat-data-provider';
+import { logger } from '~/utils';
 
 export default function resetConvo(messages: TMessage[], sender: string) {
   if (messages.length === 0) {
@@ -7,7 +8,8 @@ export default function resetConvo(messages: TMessage[], sender: string) {
   const modelMessages = messages.filter((message) => !message.isCreatedByUser);
   const lastModel = modelMessages[modelMessages.length - 1].sender;
   if (lastModel !== sender) {
-    console.log(
+    logger.log(
+      'convo',
       'Model change! Resetting convo. Original messages: ',
       messages,
       'filtered messages: ',


### PR DESCRIPTION
## Summary
- remove stray `console.log` usages
- install missing dependencies
- use logger in several client components, hooks, and utils

## Testing
- `npm run lint` *(fails: 127 errors, 57 warnings)*
- `npm test` *(fails: Missing script 'test')*

------
https://chatgpt.com/codex/tasks/task_e_685301f015f083209b6365a9ec1bc515